### PR TITLE
Adapt to signedness of `hashCode()`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 dependencies {
@@ -72,11 +73,14 @@ dependencies {
 }
 tasks.withType(JavaCompile).configureEach {
   // "-processing" avoids javac warning "No processor claimed any of these annotations".
-  options.compilerArgs << '-Xlint:all,-processing' << '-Werror'
+  // "-options" is because starting in JDK 20, javac warns about using -source 8.
+  options.compilerArgs << '-Xlint:all,-processing,-options' << '-Werror'
   options.errorprone {
     enabled = JavaVersion.current() != JavaVersion.VERSION_1_8
     disable('ReferenceEquality') // Use Interning Checker instead.
   }
+  options.forkOptions.jvmArgs += '-Xmx2g'
+  options.release = 8
 }
 
 /// Checker Framework pluggable type-checking
@@ -100,13 +104,27 @@ checkerFramework {
   ]
   extraJavacArgs = [
     '-Werror',
+    // '-Aversion',
+    // '-verbose',
     '-AcheckPurityAnnotations',
     '-ArequirePrefixInWarningSuppressions',
     '-AwarnRedundantAnnotations',
     '-AwarnUnneededSuppressions',
   ]
 }
-
+// To use a snapshot version of the Checker Framework.
+if (true) {
+  // TODO: change the above test to false when CF is released
+  ext.checkerFrameworkVersion = '3.34.1-SNAPSHOT'
+  dependencies {
+    compileOnly "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
+    testCompileOnly "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
+    checkerFramework "org.checkerframework:checker:${checkerFrameworkVersion}"
+  }
+  configurations.all {
+    resolutionStrategy.cacheChangingModulesFor 0, 'minutes'
+  }
+}
 // To use a locally-built Checker Framework, run gradle with "-PcfLocal".
 if (project.hasProperty('cfLocal')) {
   def cfHome = String.valueOf(System.getenv('CHECKERFRAMEWORK'))

--- a/src/main/java/org/plumelib/multiversioncontrol/MultiVersionControl.java
+++ b/src/main/java/org/plumelib/multiversioncontrol/MultiVersionControl.java
@@ -33,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 import org.checkerframework.checker.regex.qual.Regex;
+import org.checkerframework.checker.signedness.qual.UnknownSignedness;
 import org.checkerframework.common.initializedfields.qual.EnsuresInitializedFields;
 import org.checkerframework.common.value.qual.MinLen;
 import org.checkerframework.dataflow.qual.Pure;
@@ -776,7 +777,7 @@ public class MultiVersionControl {
 
     @Override
     @Pure
-    public int hashCode(@GuardSatisfied Checkout this) {
+    public int hashCode(@GuardSatisfied @UnknownSignedness Checkout this) {
       return Objects.hash(repoType, canonicalDirectory, module);
     }
 


### PR DESCRIPTION
Merge together:
https://github.com/typetools/checker-framework/pull/5848
https://github.com/typetools/jdk/pull/173
https://github.com/codespecs/daikon/pull/474
https://github.com/plume-lib/multi-version-control/pull/221
https://github.com/plume-lib/plume-util/pull/295
