### PR TITLE
Fixing dead (404) `manage-git-clones` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Add to your shell startup file, such as `~/.profile`:
 alias mvc='java -ea -cp SOME_DIRECTORY/multi-version-control/build/libs/multi-version-control-all.jar org.plumelib.multiversioncontrol.MultiVersionControl'
 ```
 
-## Other scripts for managing multiple git clones
+## Other scripts for managing multiple git branches
 
-See the scripts in [manage-git-clones](https://github.com/plume-lib/manage-git-clones).
+See the scripts in [manage-git-branches](https://github.com/plume-lib/manage-git-branches).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Add to your shell startup file, such as `~/.profile`:
 alias mvc='java -ea -cp SOME_DIRECTORY/multi-version-control/build/libs/multi-version-control-all.jar org.plumelib.multiversioncontrol.MultiVersionControl'
 ```
 
-## Other scripts for managing multiple git branches
+## Other scripts for managing multiple git clones and branches
 
 See the scripts in [manage-git-branches](https://github.com/plume-lib/manage-git-branches).


### PR DESCRIPTION
The `README.md` previously referenced a link to the `manage-git-clones` repo, which no longer exists.

I am submitting a patch to change the link to the `manage-git-branches` repo, which I believe is the successor to `manage-git-clones`. Please let me know if this is not the case so I can update this PR with the correct repository link.