### PR TITLE
Guard directory printing with Git repo type check

### DIFF
--- a/src/main/java/org/plumelib/multiversioncontrol/MultiVersionControl.java
+++ b/src/main/java/org/plumelib/multiversioncontrol/MultiVersionControl.java
@@ -1854,8 +1854,10 @@ public class MultiVersionControl {
 
       if (printDirectory) {
         System.out.println(dir + " :");
-        pb5.directory(dir);
-        perform_command(pb5, Collections.emptyList(), true);
+        if (c.repoType == RepoType.GIT && dir.isDirectory()) {
+          pb5.directory(dir);
+          perform_command(pb5, Collections.emptyList(), true);
+        }
       }
       perform_command(pb, replacers, showNormalOutput);
       if (!pb2.command().isEmpty()) {


### PR DESCRIPTION
## Summary
Added a guard condition to prevent directory printing operations from executing on non-Git repositories or non-existent directories.

## Key Changes
- Wrapped the directory printing command execution with a check that verifies:
  - The repository type is Git (`c.repoType == RepoType.GIT`)
  - The directory exists and is a valid directory (`dir.isDirectory()`)
- This prevents attempting to execute Git-specific commands on other version control systems or invalid paths

## Implementation Details
The `pb5` command (which appears to be a Git-specific operation) is now only executed when both conditions are met. This is a defensive programming measure that avoids errors when processing checkouts from non-Git repositories or when the directory path is invalid.

https://claude.ai/code/session_01YSdiJYVG5EoWrPcGUb4Ygf